### PR TITLE
raise ConnectionError if sim is not running

### DIFF
--- a/SimConnect/SimConnect.py
+++ b/SimConnect/SimConnect.py
@@ -166,7 +166,7 @@ class SimConnect:
 					pass
 		except OSError:
 			LOGGER.debug("Did not find Flight Simulator running.")
-			exit(0)
+			raise ConnectionError("Did not find Flight Simulator running.")
 
 	def _run(self):
 		while self.quit == 0:


### PR DESCRIPTION
This raises a `ConnectionError` if a DLL error indicates the sim is not running - instead of immediately exiting. This allows applications using the libary to be able to catch cases where the connection failed so that they can inform the user or retry the operation later.

#44