### PR TITLE
Added argument types to RequestSystemState.

### DIFF
--- a/SimConnect/Attributes.py
+++ b/SimConnect/Attributes.py
@@ -755,7 +755,7 @@ class SimConnectDll(object):
 		#   const char * szState);
 		self.RequestSystemState = self.SimConnect.SimConnect_RequestSystemState
 		self.RequestSystemState.restype = HRESULT
-		self.RequestSystemState.argtypes = []
+		self.RequestSystemState.argtypes = [HANDLE,SIMCONNECT_DATA_REQUEST_ID, c_char_p]
 
 		# SIMCONNECTAPI SimConnect_SetSystemState(
 		#   HANDLE hSimConnect,


### PR DESCRIPTION
I was trying to get the Flight Plan file and noticed that the RequestSystemState function setup doesn't have the required parameters set so the call fails. Should fix #71.